### PR TITLE
refactor: explicit include stdlib to avoid ambiguous overloads

### DIFF
--- a/src/CollisionDetector.cpp
+++ b/src/CollisionDetector.cpp
@@ -2,6 +2,7 @@
 #include <algorithm>
 #include <vector>
 #include <cassert>
+#include <stdlib.h>
 
 #include "Entity.h"
 #include "EntityShape.h"
@@ -224,7 +225,7 @@ namespace flat2d
 		if (yvel > 0) {
 			yvel -= 50;
 		}
-		if (std::abs(yvel) <= 300) {
+		if (abs(yvel) <= 300) {
 			yvel = 0;
 		}
 
@@ -239,7 +240,7 @@ namespace flat2d
 		if (xvel > 0) {
 			xvel -= 50;
 		}
-		if (std::abs(xvel) <= 300) {
+		if (abs(xvel) <= 300) {
 			xvel = 0;
 		}
 


### PR DESCRIPTION
Hi,

I get this compiler error while make it from OSX.
```
.../flat/src/CollisionDetector.cpp:227:7: error: call to 'abs' is ambiguous
                if (std::abs(yvel) <= 300) {
                    ^~~~~~~~
/Library/Developer/CommandLineTools/SDKs/MacOSX10.14.sdk/usr/include/stdlib.h:132:6: note: candidate function
int      abs(int) __pure2;
         ^
/Library/Developer/CommandLineTools/usr/include/c++/v1/stdlib.h:111:44: note: candidate function
inline _LIBCPP_INLINE_VISIBILITY long      abs(     long __x) _NOEXCEPT {return  labs(__x);}
                                           ^
/Library/Developer/CommandLineTools/usr/include/c++/v1/stdlib.h:113:44: note: candidate function
inline _LIBCPP_INLINE_VISIBILITY long long abs(long long __x) _NOEXCEPT {return llabs(__x);}
```
Looking around and people say that we need to explicitly use the stdlib overload.

Thanks.
